### PR TITLE
Call reject block on dismiss

### DIFF
--- a/App.js
+++ b/App.js
@@ -37,7 +37,13 @@ export default class App extends Component<{}> {
             this.token,
             applicantId,
             () => { this.setTextContent("Verification complete", "To perform another verification, press \"Launch\"") },
-            (errorCause) => { this.setTextContent("Flow not finished", "To try again, press \"Launch\"") }
+            (errorCause) => {
+              if (errorCause == "USER_LEFT_ACTIVITY") {
+                this.setTextContent("Flow cancelled", "To try again, press \"Launch\"")
+              } else {
+                this.setTextContent("Flow not finished", "To try again, press \"Launch\"")
+              }
+            }
           );
       })
   }

--- a/ios/ReactNativeSampleApp/OnfidoSDK.swift
+++ b/ios/ReactNativeSampleApp/OnfidoSDK.swift
@@ -42,6 +42,7 @@ class OnfidoSDK: NSObject {
           self?.dismiss()
           resolve([id])
         case .cancel:
+          reject(["USER_LEFT_ACTIVITY"])
           self?.dismiss()
         }
       })


### PR DESCRIPTION
**Problem**
On android, tapping back button returns 'USER_LEFT_ACTIVITY' in the error handler. However iOS doesn't resolve the promise

**Solution**
Added statement to call reject block whenever user dismiss SDK flow on iOS